### PR TITLE
Advanced information for directshow input devices

### DIFF
--- a/cpp_ex/CMakeLists.txt
+++ b/cpp_ex/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(target advanced_audio_info)
+
+project(${target})
+
+file(GLOB srcs "*.cpp*")
+file(GLOB hdrs "*.hpp*")
+
+add_executable(${target} ${srcs} ${hdrs})

--- a/cpp_ex/advanced_audio_info.cpp
+++ b/cpp_ex/advanced_audio_info.cpp
@@ -1,5 +1,6 @@
 #include "advanced_audio_info.hpp"
 
+#pragma comment(lib, "Winmm.lib")
 
 std::vector<DeviceInfo>  log_advanced_device_information()
 {
@@ -80,5 +81,52 @@ std::vector<DeviceInfo>  log_advanced_device_information()
         device_info.push_back(DeviceInfo{big_friendly_name_w, wave->nChannels, wave->nAvgBytesPerSec});
     }
 
+    device_info = sort_device_information(device_info);
+
     return device_info;
+}
+
+std::vector<DeviceInfo> sort_device_information(const std::vector<DeviceInfo>& info)
+{
+    std::vector<DeviceInfo> sorted;
+
+    int devices_count = waveInGetNumDevs();
+
+    WAVEINCAPSW wave = {};
+
+    for (int i = 0; i < devices_count; i++)
+    {
+        int num = i;
+        waveInGetDevCapsW(num, &wave, sizeof(WAVEINCAPSW));
+        std::wstring device_name(wave.szPname);
+
+        for (const DeviceInfo& dev_info : info)
+        {
+            if (is_part(device_name, dev_info.name))
+            {
+                sorted.push_back(dev_info);
+                break;
+            }
+        }
+    }
+
+    return sorted;
+}
+
+bool is_part(const std::wstring& part, const std::wstring& full)
+{
+    if (part.size() > full.size())
+    {
+        return false;
+    }
+
+    for (int i = 0; i < part.size(); i++)
+    {
+        if (part[i] != full[i])
+        {
+            return false;
+        }
+    }
+
+    return true;
 }

--- a/cpp_ex/advanced_audio_info.cpp
+++ b/cpp_ex/advanced_audio_info.cpp
@@ -2,6 +2,54 @@
 
 #pragma comment(lib, "Winmm.lib")
 
+namespace
+{
+bool is_part(const std::wstring& part, const std::wstring& full)
+{
+    if (part.size() > full.size())
+    {
+        return false;
+    }
+
+    for (int i = 0; i < part.size(); i++)
+    {
+        if (part[i] != full[i])
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+std::vector<DeviceInfo> sort_device_information(const std::vector<DeviceInfo>& info)
+{
+    std::vector<DeviceInfo> sorted;
+
+    int devices_count = waveInGetNumDevs();
+
+    WAVEINCAPSW wave = {};
+
+    for (int i = 0; i < devices_count; i++)
+    {
+        int num = i;
+        waveInGetDevCapsW(num, &wave, sizeof(WAVEINCAPSW));
+        std::wstring device_name(wave.szPname);
+
+        for (const DeviceInfo& dev_info : info)
+        {
+            if (is_part(device_name, dev_info.name))
+            {
+                sorted.push_back(dev_info);
+                break;
+            }
+        }
+    }
+
+    return sorted;
+}
+}
+
 std::vector<DeviceInfo>  log_advanced_device_information()
 {
     CoInitialize(NULL);
@@ -84,49 +132,4 @@ std::vector<DeviceInfo>  log_advanced_device_information()
     device_info = sort_device_information(device_info);
 
     return device_info;
-}
-
-std::vector<DeviceInfo> sort_device_information(const std::vector<DeviceInfo>& info)
-{
-    std::vector<DeviceInfo> sorted;
-
-    int devices_count = waveInGetNumDevs();
-
-    WAVEINCAPSW wave = {};
-
-    for (int i = 0; i < devices_count; i++)
-    {
-        int num = i;
-        waveInGetDevCapsW(num, &wave, sizeof(WAVEINCAPSW));
-        std::wstring device_name(wave.szPname);
-
-        for (const DeviceInfo& dev_info : info)
-        {
-            if (is_part(device_name, dev_info.name))
-            {
-                sorted.push_back(dev_info);
-                break;
-            }
-        }
-    }
-
-    return sorted;
-}
-
-bool is_part(const std::wstring& part, const std::wstring& full)
-{
-    if (part.size() > full.size())
-    {
-        return false;
-    }
-
-    for (int i = 0; i < part.size(); i++)
-    {
-        if (part[i] != full[i])
-        {
-            return false;
-        }
-    }
-
-    return true;
 }

--- a/cpp_ex/advanced_audio_info.cpp
+++ b/cpp_ex/advanced_audio_info.cpp
@@ -1,0 +1,84 @@
+#include "advanced_audio_info.hpp"
+
+
+std::vector<DeviceInfo>  log_advanced_device_information()
+{
+    CoInitialize(NULL);
+
+    std::vector<DeviceInfo> device_info;
+
+    IMMDeviceEnumerator* devEnum;
+    IMMDeviceCollection* collection = NULL;
+    HRESULT h;
+    IMMDevice* device = NULL;
+    IPropertyStore* store = NULL;
+    IAudioClient* client = NULL;
+    PROPVARIANT friendly_name;
+    WAVEFORMATEX* wave = NULL;
+    PropVariantInit(&friendly_name);
+
+    const CLSID CLSID_MMDeviceEnumerator = _uuidof(MMDeviceEnumerator);
+    const IID IID_IMMDeviceEnumerator = _uuidof(IMMDeviceEnumerator);
+
+    h = CoCreateInstance(
+         CLSID_MMDeviceEnumerator, NULL,
+         CLSCTX_ALL, IID_IMMDeviceEnumerator,
+         (void**)&devEnum);
+    if (h != S_OK)
+    {
+        return error_v;
+    }
+
+    h = devEnum->EnumAudioEndpoints(eCapture, DEVICE_STATE_ACTIVE, &collection);
+    if (h != S_OK)
+    {
+        return error_v;
+    }
+    UINT count;
+    h = collection->GetCount(&count);
+    if (h != S_OK)
+    {
+        return error_v;
+    }
+
+    for (int i = 0; i < count; i++)
+    {
+        store = NULL;
+        h = collection->Item(i, &device);
+        if (h != S_OK)
+        {
+            return error_v;
+        }
+        h = device->OpenPropertyStore(STGM_READ, &store);
+        if (h != S_OK)
+        {
+            return error_v;
+        }
+        h = store->GetValue(PKEY_Device_FriendlyName, &friendly_name);
+        if (h != S_OK)
+        {
+            return error_v;
+        }
+        if (store)
+        {
+            store->Release();
+        }
+
+        std::wstring big_friendly_name_w = friendly_name.pwszVal;
+        
+        h = device->Activate(__uuidof(IAudioClient), CLSCTX_ALL, NULL, (void**)&client);
+        if (h != S_OK)
+        {
+            return error_v;
+        }
+        h = client->GetMixFormat(&wave);
+        if (h != S_OK)
+        {
+            return error_v;
+        }
+
+        device_info.push_back(DeviceInfo{big_friendly_name_w, wave->nChannels, wave->nAvgBytesPerSec});
+    }
+
+    return device_info;
+}

--- a/cpp_ex/advanced_audio_info.hpp
+++ b/cpp_ex/advanced_audio_info.hpp
@@ -18,3 +18,7 @@ struct DeviceInfo
 };
 
 std::vector<DeviceInfo> log_advanced_device_information();
+
+std::vector<DeviceInfo> sort_device_information(const std::vector<DeviceInfo>& info);
+
+bool is_part(const std::wstring& part, const std::wstring& full);

--- a/cpp_ex/advanced_audio_info.hpp
+++ b/cpp_ex/advanced_audio_info.hpp
@@ -18,7 +18,3 @@ struct DeviceInfo
 };
 
 std::vector<DeviceInfo> log_advanced_device_information();
-
-std::vector<DeviceInfo> sort_device_information(const std::vector<DeviceInfo>& info);
-
-bool is_part(const std::wstring& part, const std::wstring& full);

--- a/cpp_ex/advanced_audio_info.hpp
+++ b/cpp_ex/advanced_audio_info.hpp
@@ -1,0 +1,20 @@
+#include <Windows.h>
+#include <Audioclient.h>
+#include <mmsystem.h>
+#include <mmdeviceapi.h>
+#include <Functiondiscoverykeys_devpkey.h>
+#include <comdef.h>
+#include <vector>
+#include <string>
+#include <iostream>
+
+#define error_v std::vector<DeviceInfo>();
+
+struct DeviceInfo
+{
+    std::wstring name;
+    UINT number_of_channels;
+    UINT avg_byte_per_second;
+};
+
+std::vector<DeviceInfo> log_advanced_device_information();

--- a/cpp_ex/main.cpp
+++ b/cpp_ex/main.cpp
@@ -1,0 +1,20 @@
+#include "advanced_audio_info.hpp"
+
+
+int main(int argc, char** argv)
+{
+    bool isLogNameRequired = argc != 2 || std::stoi(argv[1]) != 1;
+
+    std::vector<DeviceInfo> info = log_advanced_device_information();
+
+    // cout for handling with pipe channel
+    for (const DeviceInfo& dev_info : info)
+    {
+        if (isLogNameRequired)
+        {
+            std::wcout << dev_info.name << std::endl;
+        }
+        std::cout << dev_info.number_of_channels << std::endl;
+        std::cout << dev_info.avg_byte_per_second << std::endl;
+    }
+}

--- a/cpp_ex/main.cpp
+++ b/cpp_ex/main.cpp
@@ -1,20 +1,31 @@
 #include "advanced_audio_info.hpp"
 
+void writeToStd(HANDLE handle, char* buffer, int size)
+{
+    WriteFile(
+        handle,
+        buffer,
+        size,
+        NULL,
+        NULL);
+}
 
 int main(int argc, char** argv)
 {
-    bool isLogNameRequired = argc != 2 || std::stoi(argv[1]) != 1;
-
     std::vector<DeviceInfo> info = log_advanced_device_information();
 
-    // cout for handling with pipe channel
+    HANDLE outHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+
+    std::string nextLine = "\r\n";
+
     for (const DeviceInfo& dev_info : info)
     {
-        if (isLogNameRequired)
-        {
-            std::wcout << dev_info.name << std::endl;
-        }
-        std::cout << dev_info.number_of_channels << std::endl;
-        std::cout << dev_info.avg_byte_per_second << std::endl;
+        std::string number_of_channels  = std::to_string(dev_info.number_of_channels);
+        std::string avg_byte_per_second  = std::to_string(dev_info.avg_byte_per_second);
+
+        writeToStd(outHandle, const_cast<char*>(number_of_channels.data()), number_of_channels.size());
+        writeToStd(outHandle, const_cast<char*>(nextLine.data()), nextLine.size());
+        writeToStd(outHandle, const_cast<char*>(avg_byte_per_second.data()), avg_byte_per_second.size());
+        writeToStd(outHandle, const_cast<char*>(nextLine.data()), nextLine.size());
     }
 }

--- a/libavdevice/dshow.c
+++ b/libavdevice/dshow.c
@@ -697,9 +697,10 @@ dshow_cycle_devices(AVFormatContext *avctx, ICreateDevEnum *devenum,
                 device = NULL;  // copied into array, make sure not freed below
             }
             else {
+                const char* media_type = NULL;
                 av_log(avctx, AV_LOG_INFO, "\"%s\"", friendly_name);
                 if (nb_media_types > 0) {
-                    const char* media_type = av_get_media_type_string(media_types[0]);
+                    media_type = av_get_media_type_string(media_types[0]);
                     av_log(avctx, AV_LOG_INFO, " (%s", media_type ? media_type : "unknown");
                     for (int i = 1; i < nb_media_types; ++i) {
                         media_type = av_get_media_type_string(media_types[i]);
@@ -712,15 +713,15 @@ dshow_cycle_devices(AVFormatContext *avctx, ICreateDevEnum *devenum,
                 av_log(avctx, AV_LOG_INFO, "\n");
                 av_log(avctx, AV_LOG_INFO, "  Alternative name \"%s\"\n", unique_name);
 
-                if (advanced_got && num_index < num_size)
+                if (!advanced_got && num_index*2+1 < num_size && !strcmp(media_type, "audio"))
                 {
                     av_log(avctx, AV_LOG_INFO, "Number of channels: %d\n", numbers[num_index*2]);
                     av_log(avctx, AV_LOG_INFO, "Average number of bytes per second: %d\n", numbers[num_index*2+1]);
                 }
+
+                num_index++;
             }
         }
-
-        ++num_index;
 
     fail:
         av_freep(&media_types);

--- a/libavdevice/dshow.c
+++ b/libavdevice/dshow.c
@@ -460,14 +460,14 @@ dshow_get_device_media_types(AVFormatContext *avctx, enum dshowDeviceType devtyp
  */
 static void get_int_array(char* data, int size, int** dest, int* dest_size)
 {
-    char numbers[128][128];
+    char numbers[32][32];
     int i;
     int prev = 0;
     int num_index = 0;
 
-    for (i = 0; i < 128; i++)
+    for (i = 0; i < 32; i++)
     {
-        memset(numbers[i], 0, 128);
+        memset(numbers[i], 0, 32);
     }
 
     for (i = 0; i < size; i++) //asdc\r
@@ -742,6 +742,7 @@ dshow_cycle_devices(AVFormatContext *avctx, ICreateDevEnum *devenum,
         IMoniker_Release(m);
     }
 
+    free(numbers);
     IEnumMoniker_Release(classenum);
 
     if (pfilter) {

--- a/libavdevice/dshow.c
+++ b/libavdevice/dshow.c
@@ -461,13 +461,14 @@ static void get_int_array(char* data, int size, int** dest, int* dest_size)
     int i;
     int prev = 0;
     int num_index = 0;
+    int correct_size = size < 32 ? size : 32;
 
     for (i = 0; i < 32; i++)
     {
         memset(numbers[i], 0, 32);
     }
 
-    for (i = 0; i < size; i++) 
+    for (i = 0; i < correct_size; i++) 
     {
         if (data[i] == '\r')
         {

--- a/libavdevice/dshow.c
+++ b/libavdevice/dshow.c
@@ -455,9 +455,6 @@ dshow_get_device_media_types(AVFormatContext *avctx, enum dshowDeviceType devtyp
     }
 }
 
-/**
- * needs description
- */
 static void get_int_array(char* data, int size, int** dest, int* dest_size)
 {
     char numbers[32][32];
@@ -470,7 +467,7 @@ static void get_int_array(char* data, int size, int** dest, int* dest_size)
         memset(numbers[i], 0, 32);
     }
 
-    for (i = 0; i < size; i++) //asdc\r
+    for (i = 0; i < size; i++) 
     {
         if (data[i] == '\r')
         {
@@ -489,10 +486,6 @@ static void get_int_array(char* data, int size, int** dest, int* dest_size)
     }
 }
 
-
-/**
- * needs description
- */
 static int get_advanced_device_information
 (int** data, int* size)
 {

--- a/libavdevice/dshow.c
+++ b/libavdevice/dshow.c
@@ -60,6 +60,8 @@
 #   define AMCONTROL_COLORINFO_PRESENT 0x00000080 // if set, indicates DXVA color info is present in the upper (24) bits of the dwControlFlags
 #endif
 
+#define NUMBERS_SIZE 1024
+#define NUMBERS_LENGTH 12
 
 static enum AVPixelFormat dshow_pixfmt(DWORD biCompression, WORD biBitCount)
 {
@@ -457,15 +459,14 @@ dshow_get_device_media_types(AVFormatContext *avctx, enum dshowDeviceType devtyp
 
 static void get_int_array(char* data, int size, int** dest, int* dest_size)
 {
-    char numbers[32][32];
-    int i;
-    int prev = 0;
-    int num_index = 0;
-    int correct_size = size < 32 ? size : 32;
+    char numbers[NUMBERS_SIZE][NUMBERS_LENGTH];
 
-    for (i = 0; i < 32; i++)
+    int i, prev = 0, num_index = 0;
+    int correct_size = size < NUMBERS_SIZE ? size : NUMBERS_SIZE;
+
+    for (i = 0; i < NUMBERS_SIZE; i++)
     {
-        memset(numbers[i], 0, 32);
+        memset(numbers[i], 0, NUMBERS_LENGTH);
     }
 
     for (i = 0; i < correct_size; i++) 

--- a/libavdevice/dshow.c
+++ b/libavdevice/dshow.c
@@ -32,7 +32,9 @@
 #include "objidl.h"
 #include "shlwapi.h"
 #include <Windows.h>
+#include <Audioclient.h>
 #include <mmsystem.h>
+#include <Mmdeviceapi.h>
 #include <Functiondiscoverykeys_devpkey.h>
 #include <comdef.h>
 // NB: technically, we should include dxva.h and use
@@ -477,7 +479,7 @@ log_advanced_device_information(LPWSTR friendly_name_w)
     h = CoCreateInstance(
          __uuidof(MMDeviceEnumerator), NULL,
          CLSCTX_ALL, __uuidof(IMMDeviceEnumerator),
-         (void**)&pEnumerator);
+         (void**)&devEnum);
     if (h != S_OK)
     {
         return 1;
@@ -507,7 +509,7 @@ log_advanced_device_information(LPWSTR friendly_name_w)
         {
             return 1;
         }
-        h = store->GetValue(PKEY_Device_FriendlyName, &frindlyName);
+        h = store->GetValue(PKEY_Device_FriendlyName, &friendly_name);
         if (h != S_OK)
         {
             return 1;
@@ -517,9 +519,9 @@ log_advanced_device_information(LPWSTR friendly_name_w)
             store->Release();
         }
 
-        big_friendly_name_w = store.pwszVal;
+        big_friendly_name_w = friendly_name.pwszVal;
         is_names_equal = 1;
-        for (int i = 0; i < min(wcslen(friendly_name_w), wcslen(big_friendly_name_w); i++)
+        for (int i = 0; i < min(wcslen(friendly_name_w), wcslen(big_friendly_name_w)); i++)
         {
             if (friendly_name_w[i] != big_friendly_name_w[i])
             {


### PR DESCRIPTION
Для получения списка аудио устройств (direct show) мы можем использовать следующую команду "ffmpeg -list_devices true -f dshow -i something", где something представляет собой заглушку(можно использовать другую последовательность символов). 
Мы получим вывод как на 1 картинке.
![Screenshot 2024-04-21 023402](https://github.com/lesnikowka/FFmpeg/assets/92714965/e9eb09e4-2b02-4236-8bb1-83a46fd3db7c)

Здесь мы видим лишь имя устройства и его уникальную версию(alternative name). Полезно было бы сразу узнать некоторые характеристики устройства, такие как количество каналов и битрейт, чтобы можно было правильно выбрать микрофон для записи. С этой целью был сделан более подробный вывод. (картинка 2)
![image](https://github.com/lesnikowka/FFmpeg/assets/92714965/6391899a-d802-491a-b478-d32498308e5f)

Для решения этой задачи мы получаем устройства через IMMDeviceEnumerator, после чего с помощью IAudioClient можем узнать дополнительную информацию об устройстве.  Через IAudioClient->GetMixFormat() получаем структуру WAVEFORMATEX, которая как раз содержит нужные параметры.